### PR TITLE
Add Shopify extraction pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.pyc
+.env
+venv/
+*.json
+!config_template.json

--- a/README.md
+++ b/README.md
@@ -1,1 +1,36 @@
-# repo_chatgpt
+# Shopify Data Extraction Pipeline
+
+This repository contains a simple pipeline script, `pp_data_extract_shpy`, that
+extracts data from Shopify stores and uploads it to Amazon S3. The script is
+configured to handle multiple stores and fetches the `orders`, `customers`, and
+`checkouts` endpoints for each store.
+
+## Setup
+
+1. Create and activate a Python 3 virtual environment.
+2. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Create a configuration file based on `config_template.json` and set the
+   environment variable `SHOPIFY_STORES_CONFIG` to its path.
+
+## Running
+
+Execute the pipeline:
+
+```bash
+python pp_data_extract_shpy.py
+```
+
+The script will read store credentials from the configuration file and upload
+JSON results for each endpoint to the configured S3 bucket.
+
+## Testing
+
+Run unit tests with:
+
+```bash
+pytest
+```
+

--- a/config_template.json
+++ b/config_template.json
@@ -1,0 +1,12 @@
+{
+  "stores": [
+    {
+      "name": "example-store",
+      "domain": "example-store.myshopify.com",
+      "api_key": "YOUR_API_KEY",
+      "password": "YOUR_PASSWORD",
+      "api_version": "2023-07",
+      "s3_bucket": "your-s3-bucket"
+    }
+  ]
+}

--- a/pp_data_extract_shpy.py
+++ b/pp_data_extract_shpy.py
@@ -1,0 +1,53 @@
+import json
+import os
+from datetime import datetime
+from typing import Dict, Any, List
+
+import boto3
+import requests
+
+
+ENDPOINTS = ["orders", "customers", "checkouts"]
+
+def fetch_endpoint(store: Dict[str, Any], endpoint: str) -> Dict[str, Any]:
+    """Fetch a single endpoint from Shopify for the given store."""
+    api_version = store.get("api_version", "2023-07")
+    url = f"https://{store['domain']}/admin/api/{api_version}/{endpoint}.json"
+    auth = (store["api_key"], store["password"])
+    response = requests.get(url, auth=auth)
+    response.raise_for_status()
+    return response.json()
+
+def upload_json_to_s3(data: Dict[str, Any], bucket: str, key: str, s3_client=None) -> None:
+    """Upload a JSON-serialisable object to S3."""
+    if s3_client is None:
+        s3_client = boto3.client("s3")
+    s3_client.put_object(Bucket=bucket, Key=key, Body=json.dumps(data))
+
+def run_store(store: Dict[str, Any], s3_client=None) -> Dict[str, Dict[str, Any]]:
+    """Fetch all endpoints for a store and upload them to S3."""
+    if s3_client is None:
+        s3_client = boto3.client("s3")
+    results: Dict[str, Dict[str, Any]] = {}
+    for endpoint in ENDPOINTS:
+        data = fetch_endpoint(store, endpoint)
+        results[endpoint] = data
+        timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+        key = f"{store['name']}/{endpoint}_{timestamp}.json"
+        upload_json_to_s3(data, store["s3_bucket"], key, s3_client=s3_client)
+    return results
+
+def run_pipeline(config: Dict[str, Any]) -> None:
+    """Run extraction for all stores defined in config."""
+    s3_client = boto3.client("s3")
+    for store in config.get("stores", []):
+        run_store(store, s3_client=s3_client)
+
+def load_config(path: str) -> Dict[str, Any]:
+    with open(path) as f:
+        return json.load(f)
+
+if __name__ == "__main__":
+    config_path = os.environ.get("SHOPIFY_STORES_CONFIG", "config.json")
+    configuration = load_config(config_path)
+    run_pipeline(configuration)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+boto3
+requests
+pytest

--- a/tests/test_pp_data_extract_shpy.py
+++ b/tests/test_pp_data_extract_shpy.py
@@ -1,0 +1,58 @@
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+# Ensure repository root is on path
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+# Stub external dependencies before importing the pipeline
+sys.modules['boto3'] = MagicMock()
+sys.modules['requests'] = MagicMock()
+
+import pp_data_extract_shpy as pipeline
+
+
+def mock_requests_get(url, auth):
+    response = MagicMock()
+    response.json.return_value = {"url": url}
+    response.raise_for_status.return_value = None
+    return response
+
+
+def test_run_store_uploads_all_endpoints():
+    store = {
+        "name": "test",
+        "domain": "test.myshopify.com",
+        "api_key": "key",
+        "password": "pwd",
+        "s3_bucket": "bucket",
+    }
+    fake_s3 = MagicMock()
+    with patch("pp_data_extract_shpy.requests.get", side_effect=mock_requests_get) as mock_get:
+        pipeline.run_store(store, s3_client=fake_s3)
+    assert mock_get.call_count == len(pipeline.ENDPOINTS)
+    assert fake_s3.put_object.call_count == len(pipeline.ENDPOINTS)
+
+
+def test_run_pipeline_multiple_stores():
+    config = {
+        "stores": [
+            {
+                "name": "s1",
+                "domain": "s1.myshopify.com",
+                "api_key": "a",
+                "password": "p",
+                "s3_bucket": "b",
+            },
+            {
+                "name": "s2",
+                "domain": "s2.myshopify.com",
+                "api_key": "a2",
+                "password": "p2",
+                "s3_bucket": "b",
+            },
+        ]
+    }
+    with patch("pp_data_extract_shpy.run_store") as mock_run_store:
+        pipeline.run_pipeline(config)
+    assert mock_run_store.call_count == len(config["stores"])


### PR DESCRIPTION
## Summary
- add generic Shopify data extraction pipeline that uploads order, customer, and checkout data to S3
- document setup and execution instructions and provide config template
- add unit tests covering S3 uploads and multi-store handling

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement boto3)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688cdc86658883228b4d34a01c10652f